### PR TITLE
Require Yii 2.0.13 for PHP 7.2 compatibility, fixes #12

### DIFF
--- a/Rollbar.php
+++ b/Rollbar.php
@@ -4,9 +4,9 @@ namespace baibaratsky\yii\rollbar;
 
 use \Rollbar\Rollbar as BaseRollbar;
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 
-class Rollbar extends Object
+class Rollbar extends BaseObject
 {
     public $accessToken;
     public $baseApiUrl = 'https://api.rollbar.com/api/1/item/';

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "rollbar/rollbar": "~1.3.3",
-        "yiisoft/yii2": "*"
+        "yiisoft/yii2": ">=2.0.13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Current version is not compatible with PHP 7.2 because it uses yii\base\Object. Yii2 changed this class name to yii\base\BaseObject in 2.0.13: https://github.com/yiisoft/yii2/blob/2.0.13/framework/UPGRADE.md#upgrade-from-yii-2012

This fixes #12 