### PR TITLE
fix correct logging of rollbar errors

### DIFF
--- a/log/Target.php
+++ b/log/Target.php
@@ -19,7 +19,8 @@ class Target extends \yii\log\Target
     public function export()
     {
         foreach ($this->messages as $message) {
-            Rollbar::log(Level::fromName(self::getLevelName($message[1])), $message[0], [
+            $levelName = self::getLevelName($message[1]);
+            Rollbar::log(Level::$levelName(), $message[0], [
                 'category' => $message[2],
                 'request_id' => $this->requestId,
                 'timestamp' => (int)$message[3],


### PR DESCRIPTION
Logging to rollbar seemed to incorrectly pass the argument to `Rollbar\LevelFactory\Level`. Ie, the `$name` variable was passed as `fromName` when in fact it should be something like `error`. 