### PR TITLE
Breaking changes: updated versions Rollbar 1.5, PHP 7.1, Yii 2.0.15

### DIFF
--- a/ErrorHandlerTrait.php
+++ b/ErrorHandlerTrait.php
@@ -2,8 +2,8 @@
 
 namespace baibaratsky\yii\rollbar;
 
-use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
+use Rollbar\Rollbar;
 use Rollbar\Utilities;
 use Yii;
 use yii\helpers\ArrayHelper;

--- a/Rollbar.php
+++ b/Rollbar.php
@@ -2,7 +2,7 @@
 
 namespace baibaratsky\yii\rollbar;
 
-use \Rollbar\Rollbar as BaseRollbar;
+use Rollbar\Rollbar as BaseRollbar;
 use Yii;
 use yii\base\BaseObject;
 
@@ -30,35 +30,28 @@ class Rollbar extends BaseObject
      * Format: ['name of the exception class', 'exception_property' => ['range', 'of', 'values], ...]
      */
     public $ignoreExceptions = [
-            ['yii\web\HttpException', 'statusCode' => [404]],
+        ['yii\web\HttpException', 'statusCode' => [404]],
     ];
 
     public function init()
     {
-        BaseRollbar::init(
-                [
-                        'access_token' => $this->accessToken,
-                        'base_api_url' => $this->baseApiUrl,
-                        'batch_size' => $this->batchSize,
-                        'batched' => $this->batched,
-                        'branch' => $this->branch,
-                        'code_version' => $this->codeVersion,
-                        'environment' => $this->environment,
-                        'host' => $this->host,
-                        'included_errno' => $this->includedErrno,
-                        'logger' => $this->logger,
-                        'person_fn' => $this->personFn,
-                        'root' => !empty($this->root) ? Yii::getAlias($this->root) : null,
-                        'scrub_fields' => $this->scrubFields,
-                        'timeout' => $this->timeout,
-                        'proxy' => $this->proxy,
-                        'enable_utf8_sanitization' => $this->enableUtf8Sanitization,
-                ],
-                false,
-                false,
-                false
-        );
-
-        parent::init();
+        BaseRollbar::init([
+            'access_token' => $this->accessToken,
+            'base_api_url' => $this->baseApiUrl,
+            'batch_size' => $this->batchSize,
+            'batched' => $this->batched,
+            'branch' => $this->branch,
+            'code_version' => $this->codeVersion,
+            'environment' => $this->environment,
+            'host' => $this->host,
+            'included_errno' => $this->includedErrno,
+            'logger' => $this->logger,
+            'person_fn' => $this->personFn,
+            'root' => !empty($this->root) ? Yii::getAlias($this->root) : null,
+            'scrub_fields' => $this->scrubFields,
+            'timeout' => $this->timeout,
+            'proxy' => $this->proxy,
+            'enable_utf8_sanitization' => $this->enableUtf8Sanitization,
+        ], false, false, false);
     }
 }

--- a/Rollbar.php
+++ b/Rollbar.php
@@ -8,6 +8,7 @@ use yii\base\BaseObject;
 
 class Rollbar extends BaseObject
 {
+    public $enabled = true;
     public $accessToken;
     public $baseApiUrl = 'https://api.rollbar.com/api/1/';
     public $batchSize;
@@ -36,6 +37,7 @@ class Rollbar extends BaseObject
     public function init()
     {
         BaseRollbar::init([
+            'enabled' => $this->enabled,
             'access_token' => $this->accessToken,
             'base_api_url' => $this->baseApiUrl,
             'batch_size' => $this->batchSize,

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "rollbar/rollbar": "1.3.1",
-        "yiisoft/yii2": ">=2.0.13"
+        "yiisoft/yii2": ">=2.0.13",
+        "rollbar/rollbar": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": ">=2.0.13",
+        "php": ">=7.1",
+        "yiisoft/yii2": "^2.0.15",
         "rollbar/rollbar": "^1.5"
     },
     "autoload": {

--- a/log/Target.php
+++ b/log/Target.php
@@ -2,8 +2,8 @@
 
 namespace baibaratsky\yii\rollbar\log;
 
-use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
+use Rollbar\Rollbar;
 use yii\log\Logger;
 
 class Target extends \yii\log\Target
@@ -31,7 +31,7 @@ class Target extends \yii\log\Target
     protected static function getLevelName($level)
     {
         if (in_array($level,
-                [Logger::LEVEL_PROFILE, Logger::LEVEL_PROFILE_BEGIN, Logger::LEVEL_PROFILE_END, Logger::LEVEL_TRACE])) {
+            [Logger::LEVEL_PROFILE, Logger::LEVEL_PROFILE_BEGIN, Logger::LEVEL_PROFILE_END, Logger::LEVEL_TRACE])) {
             return 'debug';
         }
 


### PR DESCRIPTION
Also Rollbar error and fatal error handlers are not used anymore, `ErrorHandlerTrait::logException()` is used to process everything: exceptions, errors, fatal errors - since PHP7 throws `\Error` exceptions instead of errors and Yii2 wraps everything else in `ErrorException`